### PR TITLE
Update base.html - Table header sticky to top of page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,10 @@
         height: 20px;
         text-decoration: none;
     }
+    th {
+        position: sticky;
+        top: 0;
+    }
 </style>
 <body>
     <i>Updated: {{ timestamp }}</i> <br/>


### PR DESCRIPTION
This change will make the header row always visible when scrolling the table