### PR TITLE
Czyszczenie tagu 'ref' przy aktualizacji stacji MEVO

### DIFF
--- a/mevo_comparator.py
+++ b/mevo_comparator.py
@@ -62,6 +62,7 @@ class Match:
     def tags(self) -> dict[str, str]:
         result = mevoNetworkTags()
         result["ref:mevo"] = self.place.ref
+        result["ref"] = ''
         result["name"] = "MEVO " + self.place.name
         result["capacity"] = str(self.place.capacity)
         return result


### PR DESCRIPTION
Pusty tag ref wysyłany do JOSM pozwoli go wyczyścić przy aktualizacji stacji MEVO. Ten tag jest nieużywany w tutejszym schemacie.